### PR TITLE
color for header link stays club purple when selected

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -110,7 +110,7 @@ const Header = () => {
             {links.map(({ href, label }) => (
               <Link key={href} href={href} className="relative">
                 <div
-                  className={`${pathname === href ? "underline underline-offset-4" : ""} hover:text-clubPurple duration-300 transition-colors`}
+                  className={`${pathname === href ? "underline underline-offset-4 text-clubPurple" : ""} hover:text-clubPurple duration-300 transition-colors`}
                 >
                   {label}
                 </div>


### PR DESCRIPTION
just added a line to make header links stay purple (+ underlined) when selected (in map section)